### PR TITLE
Fix datagrip postremove procedure

### DIFF
--- a/packages/datagrip/postremove
+++ b/packages/datagrip/postremove
@@ -2,4 +2,4 @@
 
 set -e
 
-rm -rf /opt/webstorm
+rm -rf /opt/datagrip


### PR DESCRIPTION
Currently datagrip isn't removed when the package is uninstalled.