### PR TITLE
remove outdated lib32gcc1 dependency

### DIFF
--- a/build-single-deb
+++ b/build-single-deb
@@ -42,7 +42,6 @@ fpm -t deb \
     --depends "default-jdk | oracle-java7-installer | oracle-java8-installer" \
     --depends "libc6-i386" \
     --depends "lib32stdc++6" \
-    --depends "lib32gcc1" \
     --depends "lib32z1" \
     --depends "lib32z1-dev" \
     --depends "unzip" \


### PR DESCRIPTION
lib32gcc1 was removed from debian, and should be removed from the dependencies.

Rebuilt package pycharm (which I use), tested, works fine without this.