### PR TITLE
use distro-info to get a list of supported distros

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
               run: gpg --import jetbrains-ppa.gpg
 
             - name: Update distributions.txt
-              run: curl -sL https://changelogs.ubuntu.com/meta-release | grep -E "^Dist:" | awk '{ print $2 }' | tail -n5 > distributions.txt
+              run: distro-info --supported > distributions.txt
             
             - name: Update packages
               run: ./update-packages


### PR DESCRIPTION
I think it makes more sense to support the 18.04 LTS, then the EOL 19.04 and 19.10

```
jim@jim:~$ curl -sL https://changelogs.ubuntu.com/meta-release | grep -E "^Dist:" | awk '{ print $2 }' | tail -n5
disco
eoan
focal
groovy
hirsute

jim@jim:~$ distro-info --supported
bionic
focal
groovy
hirsute
impish
```