### PR TITLE
Include 'rustrover-eap' in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently, the following packages are supported and automatically updated using 
 * PyCharm Professional `pycharm-professional`
 * Rider `rider`
 * RubyMine `rubymine`
+* RustRover (Early Access Program) `rustrover-eap`
 * WebStorm `webstorm`
 
 ## Installation


### PR DESCRIPTION
Included 'rustrover-eap' in the readme so that it will be visible for others to use.

REF: https://github.com/JonasGroeger/jetbrains-ppa/pull/67#issuecomment-1908837313