### PR TITLE
fix: use icon provided by icon theme

### DIFF
--- a/packages/intellij-idea-community/usr/share/applications/intellij-idea-community.desktop
+++ b/packages/intellij-idea-community/usr/share/applications/intellij-idea-community.desktop
@@ -2,7 +2,7 @@
 Name=IntelliJ IDEA Community
 Comment=Java, Groovy, Scala and Android development.
 Exec=intellij-idea-community %u
-Icon=/opt/intellij-idea-community/bin/idea.svg
+Icon=idea
 Terminal=false
 Type=Application
 Categories=Development;IDE;


### PR DESCRIPTION
Instead of pointing to a desktop icon file bundled with the PPA, use the icon provided by the icon theme used by the system, e.g. Numix Circle.